### PR TITLE
comment parseFloat of numeric string to maintain the same value

### DIFF
--- a/oat_pivotTable.js
+++ b/oat_pivotTable.js
@@ -153,7 +153,8 @@ var OAT = {};
 					if ((picture != undefined) && (picture != "")) {
 						
 						if (typeof qv == "undefined")
-							var newValue = parseFloat(value)
+							var newValue = value;
+							//var newValue = parseFloat(value)
 						else
 							qv.util.formatNumber(parseFloat(value), decimalPlaces, picture, false);
 						


### PR DESCRIPTION
- Comment parsefloat to keep original numeric string value, used in reporting-controls-library